### PR TITLE
Hide flathubbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Hide comments from certain authors or with certain text. Enhance blockquote in c
   - codspeed-hq
   - typescript-eslint
   - nx-cloud
-	- flathubbot
+  - flathubbot
 - Hide comments with text matching:
   - starts with `!` or `/`
   - Astro's preview release bot output
-	- "bot, build"
+  - "bot, build"
 - Edit the script to optionally hide all bot comments (has a "bot" tag next to its name)
 - Collapse whole-comment quote-replies
 - Link to original quote for partial quote-replies

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ Hide comments from certain authors or with certain text. Enhance blockquote in c
   - codspeed-hq
   - typescript-eslint
   - nx-cloud
+	- flathubbot
 - Hide comments with text matching:
   - starts with `!` or `/`
   - Astro's preview release bot output
+	- "bot, build"
 - Edit the script to optionally hide all bot comments (has a "bot" tag next to its name)
 - Collapse whole-comment quote-replies
 - Link to original quote for partial quote-replies

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ const authorsToMinimize = [
   'codspeed-hq',
   'typescript-eslint',
   'nx-cloud',
+  'flathubbot'
 ]
 
 // common comments that don't really add value
@@ -37,6 +38,7 @@ const commentMatchToMinimize = [
   /^![a-z]/, // commands that start with !
   /^\/[a-z]/, // commands that start with /
   /^> root@0.0.0/, // astro preview release bot
+  /^bot, build/
 ]
 
 // #endregion


### PR DESCRIPTION
The vast majority of flathubbot comments are test build status updates, and multiple are created for each build attempt, on top of the required "bot, build" comment to activate it. This adds up to literally dozens of comments per pull request.